### PR TITLE
Include `signInFeature` in the features for `SolanaWalletAdapterWallet`

### DIFF
--- a/packages/wallet-adapter/base/src/wallet.ts
+++ b/packages/wallet-adapter/base/src/wallet.ts
@@ -162,7 +162,12 @@ export class SolanaWalletAdapterWallet implements Wallet {
             };
         }
 
-        return { ...features, ...signTransactionFeature, ...signMessageFeature };
+        return {
+            ...features,
+            ...signTransactionFeature,
+            ...signMessageFeature,
+            ...signInFeature,
+        };
     }
 
     get accounts() {


### PR DESCRIPTION
`SolanaWalletAdapterWallet` was missing `signInFeature`, so anything wrapped it in would be missing the `signIn` method.