### PR TITLE
A test matcher that asserts whether an object is frozen

### DIFF
--- a/packages/test-matchers/_/package.json
+++ b/packages/test-matchers/_/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "@wallet-standard/test-matchers",
+    "version": "0.0.0",
+    "private": true,
+    "files": [
+        "toBeFrozenObject.ts"
+    ]
+}

--- a/packages/test-matchers/_/toBeFrozenObject.ts
+++ b/packages/test-matchers/_/toBeFrozenObject.ts
@@ -1,0 +1,22 @@
+expect.extend({
+    toBeFrozenObject(actual: object) {
+        return {
+            message: () => `Expected object ${this.isNot ? 'not ' : ''}to be frozen`,
+            pass: Object.isFrozen(actual),
+        };
+    },
+});
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace jest {
+        interface AsymmetricMatchers {
+            toBeFrozenObject(): void;
+        }
+        interface Matchers<R> {
+            toBeFrozenObject(): R;
+        }
+    }
+}
+
+export {};

--- a/packages/test-matchers/_/tsconfig.json
+++ b/packages/test-matchers/_/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "Test Matchers",
+    "compilerOptions": {
+        "composite": false,
+        "declaration": true,
+        "declarationMap": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "inlineSources": false,
+        "isolatedModules": true,
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "preserveWatchOutput": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ESNext"
+    },
+    "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,8 @@ importers:
         specifier: ^29.6.3
         version: 29.6.3
 
+  packages/test-matchers/_: {}
+
   packages/tmp/parcel-packager-webextension:
     dependencies:
       '@parcel/plugin':


### PR DESCRIPTION
This is a custom expectation that lets you assert an object is frozen. We'll use this later on in the stack to write tests for the new wallet registry (for the React hooks).