### PR TITLE
A `useWallets()` hook that only vends handles

### DIFF
--- a/.changeset/fresh-monkeys-compare.md
+++ b/.changeset/fresh-monkeys-compare.md
@@ -1,0 +1,5 @@
+---
+'@wallet-standard/react-core': major
+---
+
+A `useWallets()` hook you can use to obtain an array of `UiWallet` objects that represent the currently registered Wallet Standard wallets. You can render these wallets in the UI of your application using the `name` and `icon` properties within, you can enumerate the `UiWalletAccount` objects authorized for the current domain through the `accounts` property, and you can use the `UiWallet` itself with compatible hooks, to materialize wallet features and more.

--- a/packages/example/react/src/App.tsx
+++ b/packages/example/react/src/App.tsx
@@ -1,26 +1,17 @@
 import { GlowWalletAdapter } from '@solana/wallet-adapter-glow';
 import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom';
 import { registerWalletAdapter, SOLANA_MAINNET_CHAIN } from '@solana/wallet-standard';
-import { useWallets, WalletProvider } from '@wallet-standard/react';
-import type { FC, ReactNode } from 'react';
+import { useWallets } from '@wallet-standard/react';
+import type { FC } from 'react';
 import React, { useEffect } from 'react';
 
 export const App: FC = () => {
-    return (
-        <Context>
-            <Content />
-        </Context>
-    );
-};
-
-const Context: FC<{ children: NonNullable<ReactNode> }> = ({ children }) => {
     useEffect(() => {
         const adapters = [new PhantomWalletAdapter(), new GlowWalletAdapter()];
         const destructors = adapters.map((adapter) => registerWalletAdapter(adapter, SOLANA_MAINNET_CHAIN));
         return () => destructors.forEach((destroy) => destroy());
     }, []);
-
-    return <WalletProvider>{children}</WalletProvider>;
+    return <Content />;
 };
 
 const Content: FC = () => {

--- a/packages/react/core/README.md
+++ b/packages/react/core/README.md
@@ -1,0 +1,9 @@
+# `@wallet-standard/react-core`
+
+This package provides React hooks for using Wallet Standard wallets, accounts, and features.
+
+## Hooks
+
+### `useWallets()`
+
+Vends an array of `UiWallet` objects; one for every registered Wallet Standard `Wallet`.

--- a/packages/react/core/package.json
+++ b/packages/react/core/package.json
@@ -38,7 +38,9 @@
         "@wallet-standard/app": "workspace:^",
         "@wallet-standard/base": "workspace:^",
         "@wallet-standard/experimental-features": "workspace:^",
-        "@wallet-standard/features": "workspace:^"
+        "@wallet-standard/features": "workspace:^",
+        "@wallet-standard/ui": "workspace:^",
+        "@wallet-standard/ui-registry": "workspace:^"
     },
     "devDependencies": {
         "@types/react": "^18.3",

--- a/packages/react/core/src/__tests__/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT-test.ts
+++ b/packages/react/core/src/__tests__/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT-test.ts
@@ -4,11 +4,11 @@ import type { StandardEventsFeature, StandardEventsListeners } from '@wallet-sta
 import { act } from 'react-test-renderer';
 
 import { renderHook } from '../test-renderer.js';
-import { useWallets } from '../useWallets.js';
+import { useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT } from '../useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT.js';
 
 jest.mock('@wallet-standard/app');
 
-describe('useWallets', () => {
+describe('useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT', () => {
     let mockGet: jest.MockedFn<ReturnType<typeof getWallets>['get']>;
     let mockOn: jest.MockedFn<ReturnType<typeof getWallets>['on']>;
     let mockRegister: jest.MockedFn<ReturnType<typeof getWallets>['register']>;
@@ -27,7 +27,7 @@ describe('useWallets', () => {
     it('returns a list of registered wallets', () => {
         const expectedWallets = [] as readonly Wallet[];
         mockGet.mockReturnValue(expectedWallets);
-        const { result } = renderHook(() => useWallets());
+        const { result } = renderHook(() => useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT());
         expect(result.current).toBe(expectedWallets);
     });
     describe.each(['register', 'unregister'])('when the %s event fires', (expectedEvent) => {
@@ -48,7 +48,7 @@ describe('useWallets', () => {
             mockGet.mockReturnValue(initialWallets);
         });
         it('updates if the wallet array has changed', () => {
-            const { result } = renderHook(() => useWallets());
+            const { result } = renderHook(() => useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT());
             const expectedWalletsAfterUpdate = ['new' as unknown as Wallet] as readonly Wallet[];
             mockGet.mockReturnValue(expectedWalletsAfterUpdate);
             act(() => {
@@ -59,7 +59,7 @@ describe('useWallets', () => {
             expect(result.current).toBe(expectedWalletsAfterUpdate);
         });
         it('does not update if the wallet array has not changed', () => {
-            const { result } = renderHook(() => useWallets());
+            const { result } = renderHook(() => useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT());
             act(() => {
                 listeners.forEach((l) => {
                     l(/* doesn't really matter what the listener receives */);
@@ -93,7 +93,7 @@ describe('useWallets', () => {
             } as const,
         ];
         mockGet.mockReturnValue(mockWallets);
-        const { result } = renderHook(() => useWallets());
+        const { result } = renderHook(() => useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT());
         act(() => {
             listeners.forEach((l) => {
                 l({

--- a/packages/react/core/src/index.ts
+++ b/packages/react/core/src/index.ts
@@ -1,3 +1,5 @@
+export * from '@wallet-standard/ui';
+
 export * from './features/index.js';
 
 export * from './useWallet.js';

--- a/packages/react/core/src/useWallets.ts
+++ b/packages/react/core/src/useWallets.ts
@@ -1,0 +1,17 @@
+import type { UiWallet } from '@wallet-standard/ui';
+import { getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from '@wallet-standard/ui-registry';
+import { useMemo } from 'react';
+
+import { useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT } from './useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT.js';
+
+/**
+ * Vends an array of `UiWallet` objects; one for every registered Wallet Standard `Wallet`.
+ */
+export function useWallets(): readonly UiWallet[] {
+    const wallets = useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT();
+    const uiWallets = useMemo(
+        () => wallets.map(getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED),
+        [wallets]
+    );
+    return uiWallets;
+}

--- a/packages/react/core/src/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT.ts
+++ b/packages/react/core/src/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT.ts
@@ -17,7 +17,7 @@ function walletHasStandardEventsFeature(wallet: Wallet): wallet is WalletWithFea
 }
 
 /** TODO: docs */
-export function useWallets(): readonly Wallet[] {
+export function useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT(): readonly Wallet[] {
     const { get, on } = useStable(getWallets);
     const prevWallets = useRef(get());
     const outputWallets = useRef(prevWallets.current);

--- a/packages/react/core/tsconfig.all.json
+++ b/packages/react/core/tsconfig.all.json
@@ -14,6 +14,12 @@
             "path": "../../experimental/features/tsconfig.all.json"
         },
         {
+            "path": "../../ui/_/tsconfig.all.json"
+        },
+        {
+            "path": "../../ui/registry/tsconfig.all.json"
+        },
+        {
             "path": "./tsconfig.cjs.json"
         },
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,12 @@ importers:
       '@wallet-standard/features':
         specifier: workspace:^
         version: link:../../core/features
+      '@wallet-standard/ui':
+        specifier: workspace:^
+        version: link:../../ui/_
+      '@wallet-standard/ui-registry':
+        specifier: workspace:^
+        version: link:../../ui/registry
     devDependencies:
       '@types/react':
         specifier: ^18.3


### PR DESCRIPTION
This is the first React hook in the new Wallet Standard React package.

```ts
function MyComponent() {
    const bitcoinWallets = useWallets().filter(({chains}) =>
        chains.some(chain => chain.startsWith('bitcoin:')),
    );
    return (
        <ul>
            {bitcoinWallets.map(
                ({name}) => <li key={name}>{name}</li>
            )}
        </ul>
    );
}
```

Characteristcs:

* Causes a rerender when a wallet is registered, unregistered, or changed
* If a wallet (or wallet account within) hasn't changed since last render it will be referentially equal to the last observed value