### PR TITLE
Add StandardEventsFeature as a return type to features()

### DIFF
--- a/.changeset/curly-moles-wave.md
+++ b/.changeset/curly-moles-wave.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-standard-wallet-adapter-base': patch
+---
+
+Fix type of features property

--- a/packages/wallet-adapter/base/src/wallet.ts
+++ b/packages/wallet-adapter/base/src/wallet.ts
@@ -106,6 +106,7 @@ export class SolanaWalletAdapterWallet implements Wallet {
 
     get features(): StandardConnectFeature &
         StandardDisconnectFeature &
+        StandardEventsFeature &
         SolanaSignAndSendTransactionFeature &
         Partial<SolanaSignTransactionFeature & SolanaSignMessageFeature & SolanaSignInFeature> {
         const features: StandardConnectFeature &


### PR DESCRIPTION
Just added StandardEventsFeature as a return type as it was missing and my IDE did not like it.