### PR TITLE
Expose connect() input and add onlyIfTrusted if silent is true

### DIFF
--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -130,8 +130,8 @@ export class StandardWalletAdapter extends BaseWalletAdapter implements Standard
         return this.#connect({ silent: true });
     }
 
-    async connect(): Promise<void> {
-        return this.#connect();
+    async connect(input?: StandardConnectInput): Promise<void> {
+        return this.#connect(input);
     }
 
     async #connect(input?: StandardConnectInput): Promise<void> {
@@ -143,7 +143,9 @@ export class StandardWalletAdapter extends BaseWalletAdapter implements Standard
 
             if (!this.#wallet.accounts.length) {
                 try {
-                    await this.#wallet.features[StandardConnect].connect(input);
+                    // `onlyIfTrusted` plays the same role as `silent`, some wallets like Phantom use `onlyIfTrusted` instead of `silent`.
+                    const connectInput = input?.silent ? { ...input, onlyIfTrusted: true } : input;
+                    await this.#wallet.features[StandardConnect].connect(connectInput);
                 } catch (error: any) {
                     throw new WalletConnectionError(error?.message, error);
                 }


### PR DESCRIPTION
Some wallets like [Phantom](https://docs.phantom.com/solana/establishing-a-connection#eagerly-connecting) use `onlyIfTrusted: true` instead of `silent: true` to attempt a connection without prompting the user. 

Summary of changes:
- Add `onlyIfTrusted` to the `connect` call params in the `StandardWalletAdapter` class if `silent` is `true`. 
- Expose the `StandardConnectInput` arguments in the public-facing `connect` method